### PR TITLE
Removed pages.size() from split_pdf

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -42,7 +42,7 @@ Rcpp::CharacterVector cpp_pdf_split(char const* infile, std::string outprefix, c
   std::vector<QPDFPageObjectHelper> pages =  QPDFPageDocumentHelper(inpdf).getAllPages();
   Rcpp::CharacterVector output(pages.size());
   for (int i = 0; i < pages.size(); i++) {
-    std::string outfile = outprefix + "_" + QUtil::int_to_string(i+1, pages.size()) + ".pdf";
+    std::string outfile = outprefix + "_" + QUtil::int_to_string(i+1) + ".pdf";
     output.at(i) = outfile;
     QPDF outpdf;
     outpdf.emptyPDF();


### PR DESCRIPTION
The addition of pages.size() creates an error in large pdfs, and it doesn't seem necessary.