### PR TITLE
Update DESCRIPTION with libjpeg system requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Suggests: 
     testthat
+SystemRequirements: libjpeg


### PR DESCRIPTION
When installing the package from source without the jpeg system requirement raises the error: `fatal error: jpeglib.h: No such file or directory`. 

Adding this to the DESCRIPTION SystemRequirement section for non-CRAN users.