### PR TITLE
Fix `pdf_combine()` "too many open files" error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 development
-  - `pdf_overlay_stamp()` gains a `pages` argument to stamp only selected pages (#29)
+  - pdf_overlay_stamp() gains a pages argument to stamp only selected pages (#29)
+  - pdf_combine() no longer throws a "too many open files" error when combining
+    large numbers of PDF files (#21)
 
 1.4.1
   - Try to fix LTO build on CRAN (do not strip static lib)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,3 +1,4 @@
+#include <qpdf/ClosedFileInputSource.hh>
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFPageDocumentHelper.hh>
 #include <qpdf/QPDFWriter.hh>
@@ -5,9 +6,16 @@
 #include <string>
 #include <Rcpp.h>
 
-static void read_pdf_with_password(char const* infile, char const* password, QPDF *pdf){
+// `use_cfis = true` uses ClosedFileInputSource so opened/closed on demand
+// this avoids "too many open files" when combining many PDFs
+static void read_pdf_with_password(char const* infile, char const* password, QPDF *pdf, bool use_cfis = false){
   try {
-    pdf->processFile(infile, password);
+    if (use_cfis) {
+      auto cis = std::make_shared<ClosedFileInputSource>(infile);
+      pdf->processInputSource(cis, password);
+    } else {
+      pdf->processFile(infile, password);
+    }
   } catch(const std::exception& e){
     if (strlen(password) == 0 && strstr(e.what(), "password") != NULL) {
       Rcpp::Function askpass = Rcpp::Environment::namespace_env("qpdf")["password_callback"];
@@ -15,10 +23,20 @@ static void read_pdf_with_password(char const* infile, char const* password, QPD
 
       //this is only for testing the new password */
       QPDF pdf2;
-      pdf2.processFile(infile, value.get_cstring());
+      if (use_cfis) {
+        auto cis2 = std::make_shared<ClosedFileInputSource>(infile);
+        pdf2.processInputSource(cis2, value.get_cstring());
+      } else {
+        pdf2.processFile(infile, value.get_cstring());
+      }
 
       //actually read it
-      pdf->processFile(infile, value.get_cstring());
+      if (use_cfis) {
+        auto cis3 = std::make_shared<ClosedFileInputSource>(infile);
+        pdf->processInputSource(cis3, value.get_cstring());
+      } else {
+        pdf->processFile(infile, value.get_cstring());
+      }
     } else {
       throw;
     }
@@ -82,10 +100,10 @@ Rcpp::CharacterVector cpp_pdf_combine(Rcpp::CharacterVector infiles, char const*
   outpdf.emptyPDF();
   for (int i = 0; i < infiles.size(); i++) {
     QPDF inpdf;
-    read_pdf_with_password(infiles.at(i), password, &inpdf);
+    read_pdf_with_password(infiles.at(i), password, &inpdf, true);
     std::vector<QPDFPageObjectHelper> pages =  QPDFPageDocumentHelper(inpdf).getAllPages();
-    for (int i = 0; i < pages.size(); i++) {
-      QPDFPageDocumentHelper(outpdf).addPage(pages.at(i), false);
+    for (int j = 0; j < pages.size(); j++) {
+      QPDFPageDocumentHelper(outpdf).addPage(pages.at(j), false);
     }
   }
   QPDFWriter outpdfw(outpdf, outfile);

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -1,0 +1,16 @@
+test_that("pdf_combine works with many files (no 'too many open files' error)", {
+  pdf_file <- "pdf-example-password.original.pdf"
+  pages_per_file <- pdf_length(pdf_file, password = "test")
+
+  outfile_2 <- tempfile(fileext = ".pdf")
+  on.exit(unlink(outfile_2), add = TRUE)
+  pdf_combine(rep_len(pdf_file, 2), outfile_2, password = "test")
+  expect_equal(pdf_length(outfile_2, password = "test"), 2 * pages_per_file)
+
+  skip("May take a few minutes and creates a 455Mb temporary file")
+  n <- 10000L
+  outfile_n <- tempfile(fileext = ".pdf")
+  on.exit(unlink(outfile_n), add = TRUE)
+  pdf_combine(rep_len(pdf_file, n), outfile_n, password = "test")
+  expect_equal(pdf_length(outfile_n, password = "test"), n * pages_per_file)
+})

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -7,10 +7,14 @@ test_that("pdf_combine works with many files (no 'too many open files' error)", 
   pdf_combine(rep_len(pdf_file, 2), outfile_2, password = "test")
   expect_equal(pdf_length(outfile_2, password = "test"), 2 * pages_per_file)
 
-  skip("May take a few minutes and creates a 455Mb temporary file")
+  skip("May take 40+ seconds and create a 31Mb temporary file")
   n <- 10000L
+  blank_file <- tempfile(fileext = ".pdf")
   outfile_n <- tempfile(fileext = ".pdf")
-  on.exit(unlink(outfile_n), add = TRUE)
-  pdf_combine(rep_len(pdf_file, n), outfile_n, password = "test")
-  expect_equal(pdf_length(outfile_n, password = "test"), n * pages_per_file)
+  on.exit(unlink(c(blank_file, outfile_n)), add = TRUE)
+  grDevices::pdf(blank_file)
+  grid::grid.newpage()
+  invisible(grDevices::dev.off())
+  pdf_combine(rep_len(blank_file, n), outfile_n)
+  expect_equal(pdf_length(outfile_n), n)
 })


### PR DESCRIPTION
* Use ClosedFileInputSource when combining PDFs so files are opened/closed on demand rather than held open throughout the write phase.
* Also fixed an inner loop variable shadowing (i → j)

closes #21