### PR TITLE
Fix configure adding trailing space to PKG_CPPFLAGS each run

### DIFF
--- a/configure
+++ b/configure
@@ -2,8 +2,14 @@
 if [ -z "$EXTERNAL_QPDF" ]; then
   echo "Using bundled qpdf (recommended)"
   if pkg-config --exists libjpeg; then
-    sed -i.bak "s#-Ilibqpdf#-Ilibqpdf `pkg-config --cflags libjpeg`#" src/Makevars
-    sed -i.bak "s#-ljpeg#`pkg-config --libs libjpeg`#" src/Makevars
+    LIBJPEG_CFLAGS=`pkg-config --cflags libjpeg`
+    LIBJPEG_LIBS=`pkg-config --libs libjpeg`
+    if [ -n "$LIBJPEG_CFLAGS" ]; then
+      sed -i.bak "s#-Ilibqpdf#-Ilibqpdf $LIBJPEG_CFLAGS#" src/Makevars
+    fi
+    if [ -n "$LIBJPEG_LIBS" ]; then
+      sed -i.bak "s#-ljpeg#$LIBJPEG_LIBS#" src/Makevars
+    fi
   fi
   exit 0
 fi


### PR DESCRIPTION
* When `pkg-config --cflags libjpeg` returns empty (standard include path), the sed substitution was replacing `-Ilibqpdf` with `-Ilibqpdf ` which adds a trailing space to `src/Makevars` every single time you run `devtools::load_all()`. 
* This change guards the sed calls so they only run when the flags are non-empty.